### PR TITLE
Uses dst's timestamp when syncing from dst to src

### DIFF
--- a/src/FolderSync.cpp
+++ b/src/FolderSync.cpp
@@ -684,7 +684,7 @@ int CFolderSync::SyncFolder( const PairData& pt )
                     {
                         std::wstring cryptpath = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.cryptpath, GetEncryptedFilename(it->first, pt.password, pt.encnames, pt.use7z, pt.useGPG)));
                         std::wstring origpath = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.origpath, it->first));
-                        if (!DecryptFile(origpath, cryptpath, pt.password, it->second, pt.useGPG))
+                        if (!DecryptFile(origpath, cryptpath, pt.password, cryptit->second, pt.useGPG))
                             retVal |= ErrorCrypt;
                     }
                 }


### PR DESCRIPTION
When syncing from dst to src, update files using dst's timestamp.

In this block of code, the `it` pointer represents file in src, whereas the `cryptit` pointer represents file in dst.
This bug only exists in batch scanning mode, not in real-time detect mode.

closes #8 