### PR TITLE
Two timestamp-related adaptations

### DIFF
--- a/lzma/Wrapper-CPP/C7Zip.cpp
+++ b/lzma/Wrapper-CPP/C7Zip.cpp
@@ -209,22 +209,26 @@ bool C7Zip::AddPath(const std::wstring& path)
 
     // set the compression properties
     bool                         encryptHeaders = (m_compressionFormat == CompressionFormat::SevenZip && !m_password.empty());
-    const size_t                 numProps       = 2;
+    const size_t                 numProps       = 4;
     const wchar_t*               names[numProps];  // = { L"x" };
     NWindows::NCOM::CPropVariant values[numProps]; // = { static_cast<UInt32>(m_compressionLevel) };
     names[0]  = L"x";
     values[0] = static_cast<UInt32>(m_compressionLevel);
+    names[1]  = L"tc"; // Stores Creation timestamps for files.
+    values[1] = true;
+    names[2]  = L"ta"; // Stores last Access timestamps for files.
+    values[2] = true;
     if (encryptHeaders)
     {
-        names[1]  = L"he";
-        values[1] = true;
+        names[3]  = L"he";
+        values[3] = true;
     }
 
     CMyComPtr<ISetProperties> setter;
     archive->QueryInterface(IID_ISetProperties, reinterpret_cast<void**>(&setter));
     if (setter != nullptr)
     {
-        hr = setter->SetProperties(names, values, encryptHeaders ? 2 : 1);
+        hr = setter->SetProperties(names, values, encryptHeaders ? numProps : numProps - 1);
         if (hr != S_OK)
         {
             return false;

--- a/lzma/Wrapper-CPP/C7Zip.cpp
+++ b/lzma/Wrapper-CPP/C7Zip.cpp
@@ -27,6 +27,7 @@
 #include "Helper.h"
 #include "../CPP/7zip/IDecl.h"
 #include "../CPP/Windows/PropVariant.h"
+#include <cassert>
 
 
 C7Zip::C7Zip()
@@ -209,26 +210,31 @@ bool C7Zip::AddPath(const std::wstring& path)
 
     // set the compression properties
     bool                         encryptHeaders = (m_compressionFormat == CompressionFormat::SevenZip && !m_password.empty());
-    const size_t                 numProps       = 4;
+    const size_t                 numProps       = 5;
     const wchar_t*               names[numProps];  // = { L"x" };
+    int                          propIndex = 0;
     NWindows::NCOM::CPropVariant values[numProps]; // = { static_cast<UInt32>(m_compressionLevel) };
-    names[0]  = L"x";
-    values[0] = static_cast<UInt32>(m_compressionLevel);
-    names[1]  = L"tc"; // Stores Creation timestamps for files.
-    values[1] = true;
-    names[2]  = L"ta"; // Stores last Access timestamps for files.
-    values[2] = true;
+
+    names[propIndex]     = L"x";
+    values[propIndex++]  = static_cast<UInt32>(m_compressionLevel);
+    names[propIndex]     = L"tc"; // Stores Creation timestamp for files.
+    values[propIndex++]  = true;
+    names[propIndex]     = L"ta"; // Stores last Access timestamp for files.
+    values[propIndex++]  = true;
+    names[propIndex]     = L"tm"; // Stores last modified timestamp for files.
+    values[propIndex++]  = true;
     if (encryptHeaders)
     {
-        names[3]  = L"he";
-        values[3] = true;
+        names[propIndex] = L"he";
+        values[propIndex++] = true;
     }
+    assert(propIndex <= numProps);  // Ensure future additions to names/values array will respect declared array size
 
     CMyComPtr<ISetProperties> setter;
     archive->QueryInterface(IID_ISetProperties, reinterpret_cast<void**>(&setter));
     if (setter != nullptr)
     {
-        hr = setter->SetProperties(names, values, encryptHeaders ? numProps : numProps - 1);
+        hr = setter->SetProperties(names, values, propIndex);
         if (hr != S_OK)
         {
             return false;

--- a/src/FolderSync.cpp
+++ b/src/FolderSync.cpp
@@ -1076,6 +1076,8 @@ bool CFolderSync::EncryptFile(const std::wstring& orig, const std::wstring& cryp
                     AdjustFileAttributes(orig.c_str(), FILE_ATTRIBUTE_ARCHIVE, 0);
                 }
 
+                // Do equivalent of Z-zip's -stl option and set archive time based on archive's file timestamp
+                // This is required to ensure future sync operations work (based on source / encrypted file's last-modified date)
                 int  retry = 5;
                 bool bRet  = true;
                 do
@@ -1092,7 +1094,7 @@ bool CFolderSync::EncryptFile(const std::wstring& orig, const std::wstring& cryp
                     if (!bRet)
                         Sleep(200);
                 } while (!bRet && (retry-- > 0));
-                if (!bRet)
+                if (!bRet) // Should archive file be erased in this case (future sync will be unreliable due to incorrect date)?
                     CCircularLog::Instance()(_T("INFO:    failed to set file time on %s"), crypt.c_str());
                 CAutoWriteLock locker(m_failureGuard);
                 m_failures.erase(orig);
@@ -1153,7 +1155,7 @@ bool CFolderSync::EncryptFile(const std::wstring& orig, const std::wstring& cryp
             if (!bRet)
                 Sleep(200);
         } while (!bRet && (retry-- > 0));
-        if (!bRet)
+        if (!bRet) // Should archive file be erased in this case (future sync will be unreliable due to incorrect date)?
             CCircularLog::Instance()(_T("INFO:    failed to set file time on %s"), crypt.c_str());
         CAutoWriteLock locker(m_failureGuard);
         m_failures.erase(orig);
@@ -1199,7 +1201,11 @@ bool CFolderSync::DecryptFile(const std::wstring& orig, const std::wstring& cryp
         CPathUtils::CreateRecursiveDirectory(targetFolder);
         if (extractor.Extract(targetFolder))
         {
-            // set the file timestamp
+#if 0
+            // Setting the file last write time is not required: 7zip will have set it based on archive content, even
+            // for files with read-only attributes (code below logs error msg for those files). Files stored on NTFS and encryypted 
+            // will have their timestamp correctly restored independantly of file system on which the encrypted archives is stored (e.g.: FAT)
+            // or on the cloud storage's ability to preserve the last modified timestamp when bringing back the archive to a local disk
             int  retry = 5;
             bool bRet  = true;
             do
@@ -1218,6 +1224,7 @@ bool CFolderSync::DecryptFile(const std::wstring& orig, const std::wstring& cryp
             } while (!bRet && (retry-- > 0));
             if (!bRet)
                 CCircularLog::Instance()(_T("ERROR:   failed to set file time on %s"), orig.c_str());
+#endif
             CAutoWriteLock locker(m_failureGuard);
             m_failures.erase(orig);
             return true;


### PR DESCRIPTION
While testing the "archive" attribute reset changes I noticed that the "last modified" timestamp was not always restored correctly. Reasons vary as per comment I put in the code I put between #if 0/#endif. Code change I propose here fix this: Decrypted files have correct "last modified" timestamp, as recorded in the encrypted file.

Testing also showed that the "created" and "last accessed" timestamp were not restored. A recent 7Zip change added ability to record a file's "last accessed" and "created" timestamps so they can be restored. Future archives created by CryptSync will have these timestamps as well with the proposed code change.