### PR TITLE
Two log issues corrections:

### DIFF
--- a/src/FolderSync.cpp
+++ b/src/FolderSync.cpp
@@ -1581,7 +1581,7 @@ bool CFolderSync::RunGPG(LPWSTR cmdline, const std::wstring& cwd) const
 
 void CFolderSync::AdjustFileAttributes(const std::wstring& fName, DWORD dwFileAttributesToClear, DWORD dwFileAttributesToSet)
 {
-    // Adjust file attributes on file without impacing file times
+    // Adjust file attributes on file without impacting file times
     WIN32_FILE_ATTRIBUTE_DATA fData = {0};
     DWORD                     error =  0;
 
@@ -1621,7 +1621,9 @@ void CFolderSync::AdjustFileAttributes(const std::wstring& fName, DWORD dwFileAt
     else
     {
         bRet            = false;
-        CAutoFile hFile = CreateFile(fName.c_str(), GENERIC_WRITE | GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+        // Use FILE_WRITE_ATTRIBUTES below to prevent sharing violation if working on 
+        // file open by another application
+        CAutoFile hFile = CreateFile(fName.c_str(), FILE_WRITE_ATTRIBUTES, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
         error           = ::GetLastError();
         if (hFile.IsValid())
         {
@@ -1669,7 +1671,7 @@ std::set<std::wstring> CFolderSync::GetNotifyIgnores()
 
 std::wstring CFolderSync::GetFileTimeStringForLog(const FILETIME& ft)
 {
-    SYSTEMTIME stUtc, stLocal;
+    SYSTEMTIME stUtc, stLocal = {0, 0, 0, 0, 0, 0, 0, 0};
     FileTimeToSystemTime(&ft, &stUtc);
     SystemTimeToTzSpecificLocalTime(nullptr, &stUtc, &stLocal);
 


### PR DESCRIPTION
Log records message "failed to set file time on <filename> while adjusting its attributes (error 32)" if I save an Excel file without exciting Excel. CryptSync detects the newly saved file, archives it successfully but logs this message.

Log records "strange" timestamp when new files are first encrypted: encrypted file is older: <source path> : 15.03.2022 - 12:23:06:000, <target path> : 52428.52428.52428 - 52428:52428:52428:52428.  Will now show 00.00.00 - 00:00:00:000 instead.