### PR TITLE
Fixing New / updated settings are not in effect when doing right-click / Sync or right-click / Sync and Exit.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,4 @@
 /Debug/Tests.ilk
 /Debug/Tests.exe
 /buildlog.txt
-/defect_descr.txt
 *.aps

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,12 @@
 /x64
 /Release
 /Tests/Release
+*.tlog
+*.obj
+*.pdb
+/Tests/Debug
+/Debug/Tests.ilk
+/Debug/Tests.exe
+/buildlog.txt
+/defect_descr.txt
+*.aps

--- a/src/OptionsDlg.cpp
+++ b/src/OptionsDlg.cpp
@@ -288,6 +288,7 @@ LRESULT COptionsDlg::DoCommand(int id)
         case ID_SYNCNOW:
         case ID_SYNCNOWANDEXIT:
         {
+            SaveSettings();
             HWND hListControl = GetDlgItem(*this, IDC_SYNCPAIRS);
             int  nCount       = ListView_GetItemCount(hListControl);
             if (nCount == 0)


### PR DESCRIPTION
Some setting changes will be lost if doing right-click / Sync and Exit. Some changes will not be in effect otherwise (such as ignore list changes or folder pair setting changes).