### PR TITLE
No functional change. Only adjustments.

### DIFF
--- a/src/PathWatcher.h
+++ b/src/PathWatcher.h
@@ -115,6 +115,7 @@ private:
 
         CAutoFile    m_hDir;                                ///< handle to the directory that we're watching
         std::wstring m_dirName;                             ///< the directory that we're watching
+        __declspec(align(sizeof(DWORD)))                    ///< buffer must be DWORD-aligned as per doc
         CHAR         m_buffer[READ_DIR_CHANGE_BUFFER_SIZE]; ///< buffer for ReadDirectoryChangesW
         OVERLAPPED   m_overlapped;
         std::wstring m_dirPath; ///< the directory name we're watching with a backslash at the end


### PR DESCRIPTION
Adjusted declaration of m_buffer to explicitly force DWORD-alignment: as per https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-readdirectorychangesw, the buffer passed to ReadDirectoryChangesW() must be DWORD-aligned.

Added CTraceToOutputDebugString to help troubleshooting. Additions are in effect if, and only if, _DEBUG is defined.

Removed first check for buffer overrun on line 199, previous statement result in the calculation always being zero. Buffer overrun check is now only done at the top of the loop.

Removed unnecessary calculation of nOffset before loop.

Replaced wcsncat_s() by wmemmove_s() to prevent source buffer read overrun, which, if Windows fills the  m_buffer to capacity, might trigger an exception.

Consolidated two re-calculations for next pnotify.