### PR TITLE
Adjustments to handling of file change notifications and sync concurrency

### DIFF
--- a/src/FolderSync.h
+++ b/src/FolderSync.h
@@ -68,7 +68,7 @@ public:
 
     void                           SyncFolders(const PairVector& pv, HWND hWnd = nullptr);
     int                            SyncFoldersWait(const PairVector& pv, HWND hWnd = nullptr);
-    void                           SyncFile(const std::wstring& path);
+    bool                           SyncFile(const std::wstring& path);
     void                           SetPairs(const PairVector& pv);
     void                           Stop();
     std::map<std::wstring, SyncOp> GetFailures();


### PR DESCRIPTION
- File change notifications are no longer silently dropped if processed concurrently to a background sync, they are now processed after the sync. This will help the deleted file reappearing issue.
- File change notifications are only requested for enabled pairs.
- Code change to prevent concurrent sync is also provided. I had done it in my repository but it is less (not?) relevant now that sync running is checked on timer trigger. Provided in case its usefulness is discovered later.
