### PR TITLE
Incompatibility of new filename encryption and gpg distributed with CryptSync

### DIFF
--- a/src/FolderSync.cpp
+++ b/src/FolderSync.cpp
@@ -1120,8 +1120,6 @@ bool CFolderSync::EncryptFile(const std::wstring& orig, const std::wstring& cryp
 
     size_t bufLen     = orig.size() + crypt.size() + password.size() + 1000;
     auto   cmdlineBuf = std::make_unique<wchar_t[]>(bufLen);
-    if ((!cryptName.empty()) && (cryptName[0] == '-'))
-        cryptName = L".\\" + cryptName;
 
     swprintf_s(cmdlineBuf.get(), bufLen, L"\"%s\" --batch --yes -c -a --passphrase \"%s\" -o \"%s\" \"%s\" ", m_gnuPg.c_str(), password.c_str(), crypt.c_str(), orig.c_str());
 


### PR DESCRIPTION
Fixes following:
- gpg.exe distributed with cryptsync failing on new encrypted name
- installing latest gpg, which supports new encrypted names, does not resolve issue as its installation path wasn't searched.
TODO: replace gpg.exe distributed with cryptsync with version supporting new filename encryption