### PR TITLE
Folder sync path watcher adjustments for max path

### DIFF
--- a/src/FolderSync.cpp
+++ b/src/FolderSync.cpp
@@ -112,6 +112,11 @@ void CFolderSync::SetPairs(const PairVector& pv)
 {
     CAutoWriteLock locker(m_guard);
     m_pairs = pv;
+    for (auto it = m_pairs.begin(); it != m_pairs.end(); ++it)
+    {
+        it->m_cryptPath = CPathUtils::AdjustForMaxPath(it->m_cryptPath);
+        it->m_origPath  = CPathUtils::AdjustForMaxPath(it->m_origPath);
+    }
 }
 
 void CFolderSync::SyncFolders(const PairVector& pv, HWND hWnd)
@@ -138,7 +143,7 @@ void CFolderSync::SyncFolders(const PairVector& pv, HWND hWnd)
         Stop();
     }
     CAutoWriteLock locker(m_guard);
-    m_pairs               = pv;
+    SetPairs(pv);
     m_parentWnd           = hWnd;
     unsigned int threadId = 0;
     InterlockedExchange(&m_bRunning, TRUE);
@@ -148,7 +153,7 @@ void CFolderSync::SyncFolders(const PairVector& pv, HWND hWnd)
 int CFolderSync::SyncFoldersWait(const PairVector& pv, HWND hWnd)
 {
     CAutoWriteLock locker(m_guard);
-    m_pairs     = pv;
+    SetPairs(pv);
     m_parentWnd = hWnd;
     InterlockedExchange(&m_bRunning, TRUE);
     return SyncFolderThread();
@@ -304,9 +309,7 @@ void CFolderSync::SyncFile(const std::wstring& plainPath, const PairData& pt)
         }
         crypt = path;
     }
-    crypt                                   = CPathUtils::AdjustForMaxPath(crypt);
-    orig                                    = CPathUtils::AdjustForMaxPath(orig);
-    path                                    = CPathUtils::AdjustForMaxPath(plainPath);
+    path                                    = plainPath;
 
     WIN32_FILE_ATTRIBUTE_DATA fDataOrig     = {};
     WIN32_FILE_ATTRIBUTE_DATA fDdataCrypt   = {};
@@ -546,7 +549,7 @@ int CFolderSync::SyncFolder(const PairData& pt)
     if (m_trayWnd)
         PostMessage(m_trayWnd, WM_PROGRESS, m_progress, m_progressTotal);
     {
-        CAutoFile hTest = CreateFile(CPathUtils::AdjustForMaxPath(pt.m_origPath).c_str(), GENERIC_READ, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+        CAutoFile hTest = CreateFile(pt.m_origPath.c_str(), GENERIC_READ, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
         if (!hTest)
         {
             CCircularLog::Instance()(L"ERROR:   error accessing path \"%s\", skipped", pt.m_origPath.c_str());
@@ -554,7 +557,7 @@ int CFolderSync::SyncFolder(const PairData& pt)
         }
     }
     {
-        CAutoFile hTest = CreateFile(CPathUtils::AdjustForMaxPath(pt.m_cryptPath).c_str(), GENERIC_READ, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+        CAutoFile hTest = CreateFile(pt.m_cryptPath.c_str(), GENERIC_READ, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
         if (!hTest)
         {
             CCircularLog::Instance()(L"ERROR:   error accessing path \"%s\", skipped", pt.m_cryptPath.c_str());
@@ -631,8 +634,8 @@ int CFolderSync::SyncFolder(const PairData& pt)
                 CTraceToOutputDebugString::Instance()(_T(__FUNCTION__) _T(": file %s does not exist in encrypted folder\n"), it->first.c_str());
                 if (bCopyOnly)
                 {
-                    std::wstring cryptPath = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_cryptPath, it->first));
-                    std::wstring origPath  = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_origPath, it->first));
+                    std::wstring cryptPath = CPathUtils::Append(pt.m_cryptPath, it->first);
+                    std::wstring origPath  = CPathUtils::Append(pt.m_origPath, it->first);
                     CCircularLog::Instance()(_T("INFO:    copy file %s to %s"), origPath.c_str(), cryptPath.c_str());
                     bool bCopyFileResult = CopyFile(origPath.c_str(), cryptPath.c_str(), FALSE);
                     if (!bCopyFileResult)
@@ -652,8 +655,8 @@ int CFolderSync::SyncFolder(const PairData& pt)
                 }
                 else
                 {
-                    std::wstring cryptPath = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_cryptPath, GetEncryptedFilename(it->first, pt.m_password, pt.m_encNames, pt.m_encNamesNew, pt.m_use7Z, pt.m_useGpg)));
-                    std::wstring origPath  = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_origPath, it->first));
+                    std::wstring cryptPath = CPathUtils::Append(pt.m_cryptPath, GetEncryptedFilename(it->first, pt.m_password, pt.m_encNames, pt.m_encNamesNew, pt.m_use7Z, pt.m_useGpg));
+                    std::wstring origPath  = CPathUtils::Append(pt.m_origPath, it->first);
                     if (!EncryptFile(origPath, cryptPath, pt.m_password, it->second, pt.m_useGpg, bCryptOnly, pt.m_compressSize, pt.m_ResetOriginalArchAttr))
                         retVal |= ErrorCrypt;
                 }
@@ -745,8 +748,8 @@ int CFolderSync::SyncFolder(const PairData& pt)
                     CTraceToOutputDebugString::Instance()(_T(__FUNCTION__) _T(": file %s is older than its encrypted partner\n"), it->first.c_str());
                     if (bCopyOnly)
                     {
-                        std::wstring cryptPath = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_cryptPath, it->first));
-                        std::wstring origPath  = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_origPath, it->first));
+                        std::wstring cryptPath = CPathUtils::Append(pt.m_cryptPath, it->first);
+                        std::wstring origPath  = CPathUtils::Append(pt.m_origPath, it->first);
                         CCircularLog::Instance()(_T("INFO:    copy file %s to %s"), cryptPath.c_str(), origPath.c_str());
                         if (!CopyFile(cryptPath.c_str(), origPath.c_str(), FALSE))
                         {
@@ -759,8 +762,8 @@ int CFolderSync::SyncFolder(const PairData& pt)
                     }
                     else
                     {
-                        std::wstring cryptPath = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_cryptPath, GetEncryptedFilename(it->first, pt.m_password, pt.m_encNames, pt.m_encNamesNew, pt.m_use7Z, pt.m_useGpg)));
-                        std::wstring origPath  = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_origPath, it->first));
+                        std::wstring cryptPath = CPathUtils::Append(pt.m_cryptPath, GetEncryptedFilename(it->first, pt.m_password, pt.m_encNames, pt.m_encNamesNew, pt.m_use7Z, pt.m_useGpg));
+                        std::wstring origPath  = CPathUtils::Append(pt.m_origPath, it->first);
                         if (!DecryptFile(origPath, cryptPath, pt.m_password, cryptIt->second, pt.m_useGpg))
                             retVal |= ErrorCrypt;
                     }
@@ -778,8 +781,8 @@ int CFolderSync::SyncFolder(const PairData& pt)
                     CTraceToOutputDebugString::Instance()(_T(__FUNCTION__) _T(": file %s is newer than its encrypted partner\n"), it->first.c_str());
                     if (bCopyOnly)
                     {
-                        std::wstring cryptPath = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_cryptPath, it->first));
-                        std::wstring origPath  = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_origPath, it->first));
+                        std::wstring cryptPath = CPathUtils::Append(pt.m_cryptPath, it->first);
+                        std::wstring origPath  = CPathUtils::Append(pt.m_origPath, it->first);
                         CCircularLog::Instance()(_T("INFO:    copy file %s to %s"), origPath.c_str(), cryptPath.c_str());
                         bool bCopyFileResult = CopyFile(origPath.c_str(), cryptPath.c_str(), FALSE);
                         if (!bCopyFileResult)
@@ -799,8 +802,8 @@ int CFolderSync::SyncFolder(const PairData& pt)
                     }
                     else
                     {
-                        std::wstring cryptPath = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_cryptPath, GetEncryptedFilename(it->first, pt.m_password, pt.m_encNames, pt.m_encNamesNew, pt.m_use7Z, pt.m_useGpg)));
-                        std::wstring origPath  = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_origPath, it->first));
+                        std::wstring cryptPath = CPathUtils::Append(pt.m_cryptPath, GetEncryptedFilename(it->first, pt.m_password, pt.m_encNames, pt.m_encNamesNew, pt.m_use7Z, pt.m_useGpg));
+                        std::wstring origPath  = CPathUtils::Append(pt.m_origPath, it->first);
                         if (!EncryptFile(origPath, cryptPath, pt.m_password, it->second, pt.m_useGpg, bCryptOnly, pt.m_compressSize, pt.m_ResetOriginalArchAttr))
                             retVal |= ErrorCrypt;
                     }
@@ -814,7 +817,7 @@ int CFolderSync::SyncFolder(const PairData& pt)
                 {
                     if (pt.m_ResetOriginalArchAttr)
                     {
-                        std::wstring origPath = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_origPath, it->first));
+                        std::wstring origPath = CPathUtils::Append(pt.m_origPath, it->first);
 
                         // Clear archive attibute
                         AdjustFileAttributes(origPath.c_str(), FILE_ATTRIBUTE_ARCHIVE, 0);
@@ -879,8 +882,8 @@ int CFolderSync::SyncFolder(const PairData& pt)
             }
             else if (bCopyOnly && (origFileList.empty() || (pt.m_syncDir == BothWays) || (pt.m_syncDir == DstToSrc)))
             {
-                std::wstring cryptPath = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_cryptPath, it->first));
-                std::wstring origPath  = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_origPath, it->first));
+                std::wstring cryptPath = CPathUtils::Append(pt.m_cryptPath, it->first);
+                std::wstring origPath  = CPathUtils::Append(pt.m_origPath, it->first);
                 CCircularLog::Instance()(_T("INFO:    copy file %s to %s"), cryptPath.c_str(), origPath.c_str());
                 // copy the file
                 if (!CopyFile(cryptPath.c_str(), origPath.c_str(), FALSE))
@@ -906,8 +909,8 @@ int CFolderSync::SyncFolder(const PairData& pt)
             {
                 // decrypt the file
                 CTraceToOutputDebugString::Instance()(_T(__FUNCTION__) _T(": decrypt file %s to %s\n"), it->first.c_str(), pt.m_origPath.c_str());
-                std::wstring cryptPath = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_cryptPath, it->second.fileRelPath));
-                std::wstring origPath  = CPathUtils::AdjustForMaxPath(CPathUtils::Append(pt.m_origPath, it->first));
+                std::wstring cryptPath = CPathUtils::Append(pt.m_cryptPath, it->second.fileRelPath);
+                std::wstring origPath  = CPathUtils::Append(pt.m_origPath, it->first);
                 if (!DecryptFile(origPath, cryptPath, pt.m_password, it->second, pt.m_useGpg))
                 {
                     retVal |= ErrorCrypt;
@@ -936,7 +939,6 @@ std::map<std::wstring, FileData, ci_lessW> CFolderSync::GetFileList(bool orig, c
     std::wstring enumpath = path;
     if ((enumpath.size() == 2) && (enumpath[1] == ':'))
         enumpath += L"\\";
-    enumpath = CPathUtils::AdjustForMaxPath(enumpath);
     CDirFileEnum                               enumerator(enumpath);
 
     std::map<std::wstring, FileData, ci_lessW> fileList;

--- a/src/PathWatcher.cpp
+++ b/src/PathWatcher.cpp
@@ -88,7 +88,7 @@ bool CPathWatcher::RemovePath(const std::wstring& path)
     CAutoWriteLock locker(m_guard);
 
     CTraceToOutputDebugString::Instance()(_T(__FUNCTION__) _T(": RemovePath for %s\n"), path.c_str());
-    bool bRet = (watchedPaths.erase(path) != 0);
+    bool bRet = (watchedPaths.erase(CPathUtils::AdjustForMaxPath(path)) != 0);
     m_hCompPort.CloseHandle();
     return bRet;
 }
@@ -97,7 +97,7 @@ bool CPathWatcher::AddPath(const std::wstring& path)
 {
     CAutoWriteLock locker(m_guard);
     CTraceToOutputDebugString::Instance()(_T(__FUNCTION__) _T(": AddPath for %s\n"), path.c_str());
-    watchedPaths.insert(path);
+    watchedPaths.insert(CPathUtils::AdjustForMaxPath(path));
     m_hCompPort.CloseHandle();
     return true;
 }
@@ -150,7 +150,7 @@ void CPathWatcher::WorkerThread()
                 CAutoReadLock locker(m_guard);
                 for (auto p = watchedPaths.cbegin(); p != watchedPaths.cend(); ++p)
                 {
-                    CAutoFile hDir = CreateFile(CPathUtils::AdjustForMaxPath(p->c_str()).c_str(),
+                    CAutoFile hDir = CreateFile(p->c_str(),
                                                 FILE_LIST_DIRECTORY,
                                                 FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                                                 nullptr, // security attributes

--- a/src/PathWatcher.h
+++ b/src/PathWatcher.h
@@ -25,7 +25,7 @@
 #include <set>
 #include <map>
 
-constexpr auto READ_DIR_CHANGE_BUFFER_SIZE = 65536;
+constexpr auto READ_DIR_CHANGE_BUFFER_SIZE = 4096;
 constexpr auto MAX_CHANGED_PATHS           = 4000;
 
 /**

--- a/src/PathWatcher.h
+++ b/src/PathWatcher.h
@@ -25,7 +25,7 @@
 #include <set>
 #include <map>
 
-constexpr auto READ_DIR_CHANGE_BUFFER_SIZE = 4096;
+constexpr auto READ_DIR_CHANGE_BUFFER_SIZE = 65536;
 constexpr auto MAX_CHANGED_PATHS           = 4000;
 
 /**


### PR DESCRIPTION
Adjusted PathWatcher and FolderSync public methods so all paths kept internally use the \\?\ prefix to remove MAX_PATH limitation.